### PR TITLE
Fix broken UTF8 handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,12 @@
 FROM ruby:2.4-alpine
 
+# Versions of mailcatcher > 0.5.12 break with UTF-8 encoded emails
 RUN apk add --update --virtual build-dependencies \
   build-base \
   ruby-dev \
   && apk add --update libstdc++ \
   sqlite-dev \
-  && gem install mailcatcher --no-rdoc --no-ri \
+  && gem install mailcatcher -v 0.5.12 --no-rdoc --no-ri \
   && apk del build-dependencies
 
 EXPOSE 1080 1025


### PR DESCRIPTION
The most current versions of mailcatcher do not correctly handle
messages with mixed encoding.  Rolling back to the last known version
that fixes the issue.